### PR TITLE
Refactors some of the logic

### DIFF
--- a/WPEmbedTTVClip/AppForm.Designer.cs
+++ b/WPEmbedTTVClip/AppForm.Designer.cs
@@ -39,9 +39,9 @@
             this.HeightLabel = new System.Windows.Forms.Label();
             this.WidthLabel = new System.Windows.Forms.Label();
             this.SuspendLayout();
-            // 
+            //
             // ConvertButton
-            // 
+            //
             this.ConvertButton.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.ConvertButton.Location = new System.Drawing.Point(11, 59);
             this.ConvertButton.Name = "ConvertButton";
@@ -50,17 +50,17 @@
             this.ConvertButton.Text = "CONVERT";
             this.ConvertButton.UseVisualStyleBackColor = true;
             this.ConvertButton.Click += new System.EventHandler(this.ConvertButton_Click);
-            // 
+            //
             // WordpressCodeLabel
-            // 
+            //
             this.WordpressCodeLabel.Location = new System.Drawing.Point(12, 126);
             this.WordpressCodeLabel.Name = "WordpressCodeLabel";
             this.WordpressCodeLabel.Size = new System.Drawing.Size(325, 109);
             this.WordpressCodeLabel.TabIndex = 4;
             this.WordpressCodeLabel.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            // 
+            //
             // StatusLabel
-            // 
+            //
             this.StatusLabel.Anchor = System.Windows.Forms.AnchorStyles.Top;
             this.StatusLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.StatusLabel.Location = new System.Drawing.Point(11, 103);
@@ -69,32 +69,32 @@
             this.StatusLabel.TabIndex = 5;
             this.StatusLabel.Text = "Ready To Convert Clipboard Link";
             this.StatusLabel.TextAlign = System.Drawing.ContentAlignment.TopCenter;
-            // 
+            //
             // DomainTextBox
-            // 
+            //
             this.DomainTextBox.Location = new System.Drawing.Point(35, 30);
             this.DomainTextBox.Name = "DomainTextBox";
             this.DomainTextBox.Size = new System.Drawing.Size(131, 23);
             this.DomainTextBox.TabIndex = 6;
-            // 
+            //
             // VideoHeightTextBox
-            // 
+            //
             this.VideoHeightTextBox.Location = new System.Drawing.Point(263, 30);
             this.VideoHeightTextBox.Name = "VideoHeightTextBox";
             this.VideoHeightTextBox.Size = new System.Drawing.Size(54, 23);
             this.VideoHeightTextBox.TabIndex = 7;
-            this.VideoHeightTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.VideoHeightTextBox_KeyPress);
-            // 
+            this.VideoHeightTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.VideoDimensionTextBox_KeyPress);
+            //
             // VideoWidthTextBox
-            // 
+            //
             this.VideoWidthTextBox.Location = new System.Drawing.Point(200, 30);
             this.VideoWidthTextBox.Name = "VideoWidthTextBox";
             this.VideoWidthTextBox.Size = new System.Drawing.Size(54, 23);
             this.VideoWidthTextBox.TabIndex = 8;
-            this.VideoWidthTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.VideoWidthTextBox_KeyPress);
-            // 
+            this.VideoWidthTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.VideoDimensionTextBox_KeyPress);
+            //
             // DomainLabel
-            // 
+            //
             this.DomainLabel.AutoSize = true;
             this.DomainLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.DomainLabel.Location = new System.Drawing.Point(73, 8);
@@ -102,9 +102,9 @@
             this.DomainLabel.Size = new System.Drawing.Size(57, 19);
             this.DomainLabel.TabIndex = 9;
             this.DomainLabel.Text = "Domain";
-            // 
+            //
             // HeightLabel
-            // 
+            //
             this.HeightLabel.AutoSize = true;
             this.HeightLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.HeightLabel.Location = new System.Drawing.Point(265, 9);
@@ -112,9 +112,9 @@
             this.HeightLabel.Size = new System.Drawing.Size(50, 19);
             this.HeightLabel.TabIndex = 10;
             this.HeightLabel.Text = "Height";
-            // 
+            //
             // WidthLabel
-            // 
+            //
             this.WidthLabel.AutoSize = true;
             this.WidthLabel.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.WidthLabel.Location = new System.Drawing.Point(204, 9);
@@ -122,9 +122,9 @@
             this.WidthLabel.Size = new System.Drawing.Size(46, 19);
             this.WidthLabel.TabIndex = 11;
             this.WidthLabel.Text = "Width";
-            // 
+            //
             // AppForm
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(350, 237);


### PR DESCRIPTION
This could break things as I don't do c# and I didn't actually compile/test, but feel free to take a look at the diff to see a couple of the changes.

It isn't about doing it in one line. Sometimes it is about reducing the cognitive load of reading things.

**Reduce cognitive load**
An example in the diff I am proposing is when one is reading `AttemptToConvertTwitchURL` one doesn't need to maintain all the cognitive load of thinking through the logical conditions of URL validation, but instead just simply reading `IsValidTwitchURL` allows us to only need to keep the boolean logic of, "If the URL is valid do this, else do X".

**Shorthand common development**
Other things are shorthand `(blah == true)` can be written `(blah)` and false logic can also be written `(!blah)` instead of `(blah == false)`

**Quick exit**
Generally, it is good practice to "escape" a function quickly. In some of the diff you'll see I'll put up the exception/false cases upfront to reduce cognitive load.

"If this validation fails, we error"

Instead of,

"if validation passes, there is all this other stuff we could be doing, and this and that, BUT if validation fails we error"

It is a lot of cognitive load to juggle while reading and such.

**DRY (Don't Repeat Yourself)**
There were two functions with the same logical operation but simply different names and I collapsed them down into one function `VideoDimensionTextBox_KeyPress`


I hope you continue on the journey and continue to big brain expand :brain: 

:lizard: 
